### PR TITLE
Ajuste na comparação do valor notificado pela Cielo

### DIFF
--- a/includes/class-wc-checkout-cielo-gateway.php
+++ b/includes/class-wc-checkout-cielo-gateway.php
@@ -267,7 +267,7 @@ class WC_Checkout_Cielo_Gateway extends WC_Payment_Gateway {
 			}
 
 			// Test if the notification is valid.
-			if ( is_object( $order ) && $amount === intval( $order->get_total() * 100 ) && $order_number === $order->id ) {
+			if ( is_object( $order ) && $amount === intval( round($order->get_total() * 100, 0) ) && $order_number === $order->id ) {
 				header( 'HTTP/1.1 200 OK' );
 
 				if ( 'yes' == $this->debug ) {


### PR DESCRIPTION
Havia um erro na conversão de tipos.

No caso que ocorreu comigo foi:

$order->get_total() retorna a string '10.20'
'10.20' * 100  resulta no float 1020
O intval neste float resulta em 1019, fazendo o a expressão retornar false.

Corrigi o problema utilizando round.